### PR TITLE
INT-6784 - skip "group has member" relationship if it was already created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 2.1.1 - 2023-01-26
+
+### Fixed
+
+- Skip `Group HAS Member` relationship creation if it was already created.
+
 ## 2.1.0 - 2021-11-10
 
 ### Added

--- a/src/steps/groups/index.ts
+++ b/src/steps/groups/index.ts
@@ -77,13 +77,23 @@ export async function fetchGroupMembers({
           return;
         }
 
-        await jobState.addRelationship(
-          createDirectRelationship({
-            _class: RelationshipClass.HAS,
-            from: groupEntity,
-            to: userEntity,
-          }),
+        const groupMemberRelationship = createDirectRelationship({
+          _class: RelationshipClass.HAS,
+          from: groupEntity,
+          to: userEntity,
+        });
+
+        const relationshipExists = await jobState.hasKey(
+          groupMemberRelationship._key,
         );
+        if (!relationshipExists) {
+          await jobState.addRelationship(groupMemberRelationship);
+        } else {
+          logger.info(
+            { relationship: groupMemberRelationship },
+            'Skipping relationship creation. Relationship already exists.',
+          );
+        }
       });
     },
   );


### PR DESCRIPTION
Skip relationship creation to prevent duplicate key error
```
{{(5:29:34 PM) - [step_failure] - Step "Fetch Group Members" failed to complete due to error. (errorCode="DUPLICATE_KEY_DETECTED", errorId="08994316-e5e6-4600-9fd6-481a6c60ff65", reason="Duplicate _key detected (_key=6f185757626e1109e84e4aa9|has|66399ee3c5fdea04d9bfac90)") }}
```